### PR TITLE
jdti 결과 로딩 원 수정, 선택지 좀 더 둥굴게 수정 > develop

### DIFF
--- a/JS/jdtiPageJS.js
+++ b/JS/jdtiPageJS.js
@@ -9,7 +9,7 @@ function jdtiNextPage(pageNumber,userChoice){
 function resultAnalysis(){
     document.getElementById("jdtiPage7").style.display="none";
     document.getElementById("jdtiProgress").style.display="none";
-    document.getElementById("jdtiResultLoading").style.display="block";
+    document.getElementById("jdtiResultLoading").style.display="flex";
     setTimeout(()=>{
         document.getElementById("jdtiSection1").style.display="none";
         document.getElementById("jdtiNullSpace1").style.display="none";

--- a/css/jdtiPage.css
+++ b/css/jdtiPage.css
@@ -102,7 +102,7 @@ main > *{
     cursor: pointer;
 }
 .jdtiOption > div > span{
-    border-radius: 4px;
+    border-radius:20px;
     background-color:burlywood;
     border:2px solid brown;
     padding:8px 2px 6px 0px;
@@ -111,30 +111,26 @@ main > *{
 }
 #jdtiResultLoading {
     display: flex;
+    justify-content: space-evenly;
 }
 #jdtiResultLoading > div{
     width:20px;
     height:20px;
     border-radius:50%;
-    position: absolute;
-    padding-top:30px;
 }
 .jdtiLoadingCircle1{
     background-color: red;
     animation:jdtiLoadingCircleAni 3s linear 2;
-    left:46.5%;
 }
 .jdtiLoadingCircle2{
     background-color: blue;
     animation:jdtiLoadingCircleAni 3s linear 2;
     animation-delay:0.5s;
-    left:49.5%;
 }
 .jdtiLoadingCircle3{
     background-color: lime;
     animation:jdtiLoadingCircleAni 3s linear 2;
     animation-delay:1s;
-    left:52.5%;
 }
 #jdtiResultName{
     font-size:24px;

--- a/jdti.html
+++ b/jdti.html
@@ -148,7 +148,6 @@
                 <button type="button" onclick="resultAnalysis()">결과보기</button>
             </div>
             <div id="jdtiResultLoading">
-                <br/>
                 <div class="jdtiLoadingCircle1"></div>
                 <div class="jdtiLoadingCircle2"></div>
                 <div class="jdtiLoadingCircle3"></div>


### PR DESCRIPTION
jdti 결과 로딩에서
display:block으로 바꾸는 js 코드로 인해 생기던 오류 수정

타원 형태로 보이게 만들던 padding 삭제

그로 인한 위치 조정을 위해 br제거

보기 좋게 만들기 위해 선택지를 좀 더 둥굴 둥굴하게 수정
